### PR TITLE
Only allow disc normal component of rim camber induced torque, and li…

### DIFF
--- a/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/Daero.cpp
+++ b/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/Daero.cpp
@@ -32,9 +32,9 @@ Also gravity.
 // this can add more stability at the end of a flight if the threshold is low enough
 // but it will also add more stability for higher spin speeds above CAVITY_EDGE_NORM_ROT_SPEED
 // need to wait and see before enabling this one
-#define CAVITY_EDGE_NORM_ROT_SPEED (80.0) // rad/s cavity lift is linearly amplified about this spin speed
+#define CAVITY_EDGE_NORM_ROT_SPEED (50.0) // rad/s cavity lift is linearly amplified about this spin speed
   #define CAVITY_EDGE_LIFT_EXP     (2.0)
-  #define CAVITY_EDGE_LIFT_GAIN    (0.1)
+  #define CAVITY_EDGE_LIFT_GAIN    (0.25)
 
 // effective area using cavity width * depth rectangle approx
 // this was shown to be aroun 0.5 by comparison with the wind tunnel models
@@ -47,7 +47,7 @@ Also gravity.
 // Pitching moment arms as a percentage of total diameter
 #define PITCHING_MOMENT_FORM_DRAG_PLATE_OFFSET (0.0)//(0.05) // % of diameter toward the front of the disc for plate drag force centre
 #define PITCHING_MOMENT_CAVITY_LIFT_OFFSET     (0.134) // % of diameter toward the back of the disc for cavity lift force centre
-#define PITCHING_MOMENT_CAMBER_LIFT_OFFSET     (0.09) // % of diameter toward the front of the disc for camber lift force centre
+#define PITCHING_MOMENT_CAMBER_LIFT_OFFSET     (0.105) // % of diameter toward the front of the disc for camber lift force centre
 // disable the lower rim camber model for now (re-evaluate later)
 #define RIM_CAMBER_EXPOSURE (0.67) // % of lower rim camber exposed to the airflow vs a rim_width * diameter rectangle
 
@@ -442,7 +442,7 @@ namespace DfisX
             throw_container->debug.debug0;
 
           // max of 1.5x
-          lift_factor_spin_bonus = 1.0 + MAX(0.5, lift_factor_spin_bonus);
+          lift_factor_spin_bonus = 1.0 + lift_factor_spin_bonus;
 
           lift_factor *= lift_factor_spin_bonus;
         }

--- a/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/Daero.cpp
+++ b/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/Daero.cpp
@@ -32,8 +32,9 @@ Also gravity.
 // this can add more stability at the end of a flight if the threshold is low enough
 // but it will also add more stability for higher spin speeds above CAVITY_EDGE_NORM_ROT_SPEED
 // need to wait and see before enabling this one
-#define CAVITY_EDGE_NORM_ROT_SPEED (50.0) // rad/s cavity lift is linearly amplified about this spin speed
-  #define CAVITY_EDGE_LIFT_EXP (1.4)
+#define CAVITY_EDGE_NORM_ROT_SPEED (80.0) // rad/s cavity lift is linearly amplified about this spin speed
+  #define CAVITY_EDGE_LIFT_EXP     (2.0)
+  #define CAVITY_EDGE_LIFT_GAIN    (0.1)
 
 // effective area using cavity width * depth rectangle approx
 // this was shown to be aroun 0.5 by comparison with the wind tunnel models
@@ -51,8 +52,8 @@ Also gravity.
 #define RIM_CAMBER_EXPOSURE (0.67) // % of lower rim camber exposed to the airflow vs a rim_width * diameter rectangle
 
 // add some runtime tuning hook-ups
-std::string gv_aero_label_debug0  = "CAVITY_EDGE_LIFT_EXP";
-double gv_aero_debug0             = (CAVITY_EDGE_LIFT_EXP);
+std::string gv_aero_label_debug0  = "CAVITY_EDGE_LIFT_GAIN";
+double gv_aero_debug0             = (CAVITY_EDGE_LIFT_GAIN);
 
 std::string gv_aero_label_debug1  = "CAVITY_EDGE_NORM_ROT_SPEED";
 double gv_aero_debug1             = (CAVITY_EDGE_NORM_ROT_SPEED);
@@ -436,10 +437,12 @@ namespace DfisX
           // Discs are really turing over stable by the time they hit the ground with CAVITY_EDGE_LIFT_EXP
           // set to 1.0. It is probably < 1
           double lift_factor_spin_bonus = 
-            pow(abs(d_state.disc_rotation_vel), throw_container->debug.debug0) / 
-            pow(throw_container->debug.debug1, throw_container->debug.debug0);
+            pow(abs(d_state.disc_rotation_vel), CAVITY_EDGE_LIFT_EXP) / 
+            pow(throw_container->debug.debug1, CAVITY_EDGE_LIFT_EXP) *
+            throw_container->debug.debug0;
 
-          lift_factor_spin_bonus = MAX(1.0, lift_factor_spin_bonus);
+          // max of 1.5x
+          lift_factor_spin_bonus = 1.0 + MAX(0.5, lift_factor_spin_bonus);
 
           lift_factor *= lift_factor_spin_bonus;
         }

--- a/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/DfisX.cpp
+++ b/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/DfisX.cpp
@@ -227,8 +227,38 @@ namespace DfisX
     {
       // generate a random disc mold index from all possible sets
       const float index = (float)rand() / (float)RAND_MAX;
-      //disc_mold = find_disc_mold_index_by_name("Mako3");
       disc_mold = floor(index * disc_object_array.size());
+
+      // OR throw a cycling set for test purposes
+      // REALLY handy for tuning, try throwing a:
+      // - straight midrange or putter with not much camber (e.g. Mako3) 
+      // - understable or stable driver with camber and a thick rim (e.g. destroyer)
+      // - stable fairway driver with a thick lower rim camber
+      // If you can get all these flying OK, you've got a decent tuning!
+      if(0)
+      {
+        static uint8_t disc2throw = 0;
+        switch(disc2throw)
+        {
+          case 0:
+            disc_mold = find_disc_mold_index_by_name("Mako3");
+            disc2throw = 1;
+            break;
+          case 1:
+            disc_mold = find_disc_mold_index_by_name("Destroyer");
+            disc2throw = 2;
+            break;
+          case 2:
+            disc_mold = find_disc_mold_index_by_name("Buzzz Foil");
+            disc2throw = 3;
+            break;
+          case 3:
+          default:
+            disc_mold = find_disc_mold_index_by_name("TeeBird");
+            disc2throw = 0;
+            break;
+        }
+      }    
     }
 
     throw_container->disc_object = disc_object_array[disc_mold];

--- a/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/DfisX.cpp
+++ b/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/DfisX.cpp
@@ -227,6 +227,7 @@ namespace DfisX
     {
       // generate a random disc mold index from all possible sets
       const float index = (float)rand() / (float)RAND_MAX;
+      //disc_mold = find_disc_mold_index_by_name("Mako3");
       disc_mold = floor(index * disc_object_array.size());
     }
 

--- a/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/disc_params.hpp
+++ b/dvd_DgrafX/Source/DiscVisionDeluxeUE/DfisX/disc_params.hpp
@@ -120,11 +120,11 @@ namespace DfisX
       /*.disc_type =*/     "Putter",
       /*.stability =*/     "Stable",
       /*.mass =*/          0.1700,
-      /*.radius =*/        0.1046,
-      /*.rim_width =*/     0.0100,
-      /*.thickness =*/     0.0202,
-      /*.rim_depth =*/     0.0138,
-      /*.edge_height =*/   0.0078
+      /*.radius =*/        0.105,
+      /*.rim_width =*/     0.009,
+      /*.thickness =*/     0.02075,
+      /*.rim_depth =*/     0.015,
+      /*.edge_height =*/   0.016
     },
     // 8
     Disc_Model


### PR DESCRIPTION
…near force to be included. This means that discs with steeper rim cambers, e.g. putters, will see less projected force into the disc normal plane, and thus, appearing as a pitch torque